### PR TITLE
[기론] 2단계: 연관 관계 매핑

### DIFF
--- a/src/main/java/qna/config/JpaConfig.java
+++ b/src/main/java/qna/config/JpaConfig.java
@@ -1,0 +1,7 @@
+package qna.config;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JpaConfig {
+}

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -12,9 +12,14 @@ public class Answer extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Long writerId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(foreignKey = @ForeignKey(name = "fk_answer_writer"))
+    private User writer;
 
-    private Long questionId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(foreignKey = @ForeignKey(name = "fk_answer_to_question"))
+    private Question question;
+
     @Lob
     private String contents;
 
@@ -39,29 +44,29 @@ public class Answer extends BaseTimeEntity {
             throw new NotFoundException();
         }
 
-        this.writerId = writer.getId();
-        this.questionId = question.getId();
+        this.writer = writer;
+        this.question = question;
         this.contents = contents;
     }
 
     public boolean isOwner(User writer) {
-        return this.writerId.equals(writer.getId());
+        return this.writer.equals(writer);
     }
 
     public void toQuestion(Question question) {
-        this.questionId = question.getId();
+        this.question = question;
     }
 
     public Long getId() {
         return id;
     }
 
-    public Long getWriterId() {
-        return writerId;
+    public User getWriter() {
+        return writer;
     }
 
-    public Long getQuestionId() {
-        return questionId;
+    public Question getQuestion() {
+        return question;
     }
 
     public String getContents() {
@@ -80,8 +85,8 @@ public class Answer extends BaseTimeEntity {
     public String toString() {
         return "Answer{" +
                 "id=" + id +
-                ", writerId=" + writerId +
-                ", questionId=" + questionId +
+                ", writer=" + writer +
+                ", question=" + question +
                 ", contents='" + contents + '\'' +
                 ", deleted=" + deleted +
                 '}';

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -1,10 +1,10 @@
 package qna.domain;
 
+import java.time.LocalDateTime;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 import java.util.Objects;
 
 @EntityListeners(AuditingEntityListener.class)
@@ -19,7 +19,9 @@ public class DeleteHistory {
 
     private Long contentId;
 
-    private Long deletedById;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(foreignKey = @ForeignKey(name = "fk_delete_history_to_user"))
+    private User deletedBy;
 
     @Column(updatable = false)
     @CreatedDate
@@ -28,26 +30,29 @@ public class DeleteHistory {
     protected DeleteHistory() {
     }
 
-    public DeleteHistory(ContentType contentType, Long contentId, Long deletedById) {
+    public DeleteHistory(ContentType contentType, Long contentId, User deletedBy) {
         this.contentType = contentType;
         this.contentId = contentId;
-        this.deletedById = deletedById;
+        this.deletedBy = deletedBy;
     }
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         DeleteHistory that = (DeleteHistory) o;
-        return Objects.equals(id, that.id) &&
-                contentType == that.contentType &&
-                Objects.equals(contentId, that.contentId) &&
-                Objects.equals(deletedById, that.deletedById);
+        return Objects.equals(id, that.id) && contentType == that.contentType && Objects.equals(
+                contentId, that.contentId) && Objects.equals(deletedBy, that.deletedBy)
+                && Objects.equals(createDate, that.createDate);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, contentType, contentId, deletedById);
+        return Objects.hash(id, contentType, contentId, deletedBy, createDate);
     }
 
     @Override
@@ -56,7 +61,7 @@ public class DeleteHistory {
                 "id=" + id +
                 ", contentType=" + contentType +
                 ", contentId=" + contentId +
-                ", deletedById=" + deletedById +
+                ", deletedBy=" + deletedBy +
                 ", createDate=" + createDate +
                 '}';
     }

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -1,5 +1,6 @@
 package qna.domain;
 
+import java.util.List;
 import javax.persistence.*;
 
 @Entity
@@ -14,7 +15,9 @@ public class Question extends BaseTimeEntity {
     @Lob
     private String contents;
 
-    private Long writerId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(foreignKey = @ForeignKey(name = "fk_question_writer"))
+    private User writer;
 
     @Column(nullable = false)
     private boolean deleted;
@@ -33,12 +36,12 @@ public class Question extends BaseTimeEntity {
     }
 
     public Question writeBy(User writer) {
-        this.writerId = writer.getId();
+        this.writer = writer;
         return this;
     }
 
     public boolean isOwner(User writer) {
-        return this.writerId.equals(writer.getId());
+        return this.writer.equals(writer);
     }
 
     public void addAnswer(Answer answer) {
@@ -49,32 +52,16 @@ public class Question extends BaseTimeEntity {
         return id;
     }
 
-    public void setId(Long id) {
-        this.id = id;
-    }
-
     public String getTitle() {
         return title;
-    }
-
-    public void setTitle(String title) {
-        this.title = title;
     }
 
     public String getContents() {
         return contents;
     }
 
-    public void setContents(String contents) {
-        this.contents = contents;
-    }
-
-    public Long getWriterId() {
-        return writerId;
-    }
-
-    public void setWriterId(Long writerId) {
-        this.writerId = writerId;
+    public User getWriter() {
+        return writer;
     }
 
     public boolean isDeleted() {
@@ -91,7 +78,7 @@ public class Question extends BaseTimeEntity {
                 "id=" + id +
                 ", title='" + title + '\'' +
                 ", contents='" + contents + '\'' +
-                ", writerId=" + writerId +
+                ", writer=" + writer +
                 ", deleted=" + deleted +
                 '}';
     }

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -47,10 +47,10 @@ public class QnaService {
 
         List<DeleteHistory> deleteHistories = new ArrayList<>();
         question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriterId()));
+        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter()));
         for (Answer answer : answers) {
             answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriterId()));
+            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter()));
         }
         deleteHistoryService.saveAll(deleteHistories);
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@ spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALS
 spring.datasource.username=sa
 
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL57Dialect
-spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.show-sql=true
 

--- a/src/test/java/qna/domain/AnswerRepositoryTest.java
+++ b/src/test/java/qna/domain/AnswerRepositoryTest.java
@@ -10,7 +10,6 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 import static qna.domain.QuestionTest.Q1;
 import static qna.domain.UserTest.JAVAJIGI;
 
@@ -27,29 +26,30 @@ class AnswerRepositoryTest {
     @Autowired
     private QuestionRepository questionRepository;
 
+    private User user;
+
+    private Question question;
+
     @BeforeEach
     void setUp() {
-        questionRepository.save(Q1);
-        userRepository.save(JAVAJIGI);
+        user = userRepository.save(JAVAJIGI);
+        question = questionRepository.save(Q1.writeBy(user));
     }
 
     @DisplayName("deleted가 false이고 해당 question Id를 가진 answer를 찾는다.")
     @Test
     void findByQuestionIdAndDeletedFalse() {
-        Answer answer = new Answer(JAVAJIGI, Q1, "내용입니다.");
+        Answer answer = new Answer(user, question, "내용입니다.");
         answerRepository.save(answer);
-        List<Answer> answers = answerRepository.findByQuestionIdAndDeletedFalse(Q1.getId());
+        List<Answer> answers = answerRepository.findByQuestionIdAndDeletedFalse(question.getId());
 
-        assertAll(
-                () -> assertThat(answers).hasSize(1),
-                () -> assertThat(answers).containsExactly(answer)
-        );
+        assertThat(answers).containsExactly(answer);
     }
 
     @DisplayName("deleted가 false이고 해당 answer Id를 가진 answer를 찾는다.")
     @Test
     void findByIdAndDeletedFalse() {
-        Answer answer = new Answer(JAVAJIGI, Q1, "내용입니다.");
+        Answer answer = new Answer(user, question, "내용입니다.");
         answerRepository.save(answer);
         Answer findAnswer = answerRepository.findByIdAndDeletedFalse(answer.getId()).get();
 

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -90,8 +90,8 @@ class QnaServiceTest {
 
     private void verifyDeleteHistories() {
         List<DeleteHistory> deleteHistories = Arrays.asList(
-                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriterId()),
-                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriterId())
+                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter()),
+                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter())
         );
         verify(deleteHistoryService).saveAll(deleteHistories);
     }


### PR DESCRIPTION
안녕하세요! 이번 미션을 하면서 궁금한 점이 생겨서 질문드립니다.

1. LMS의 힌트에서 
```java
Question question = findQuestionById(questionId);
List<Answer> answers = question.getAnswers();
```
와 같이 객체간의 관계를 통해서 참조를 하려면 엔티티간의 양방향 매핑이 필요한 것 같았습니다. 왜냐하면 단방향으로 하면 Question에 Answer의 객체가 없기 때문입니다. 하지만 양방향 매핑은 `순환 참조` 또는 `외래키가 있는 곳에서만 변경을 가할 수 있다` 등 관리하는 복잡도가 높아져서 최대한 단방향 매핑으로만 하는 것이 좋다고 공부했습니다.

그렇다면 단방향으로 안전하게 가져가는 방법으로는 객체 지향적이기는 힘든걸까요? 네오의 생각이 궁금합니다!

2. 이전 pr의 [코멘트](https://github.com/woowacourse/jwp-qna/pull/22#discussion_r918550516)에 남겼듯이 @EnableJpaAuditing 이 여전히 동작하지 않습니다.😂  해결 방법을 찾아보려고 했는데 도저히 모르겠네요. 관련해서 힌트라도 주시면 감사하겠습니다.

