### PR TITLE
[1단계 - 엔티티 매핑] 아벨 미션 제출합니다

### DIFF
--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -3,14 +3,40 @@ package qna.domain;
 import qna.NotFoundException;
 import qna.UnAuthorizedException;
 
+import java.time.LocalDateTime;
 import java.util.Objects;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "answer")
 public class Answer {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private Long writerId;
-    private Long questionId;
+
+    @Lob
     private String contents;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(nullable = false)
     private boolean deleted = false;
+
+    private Long questionId;
+    private LocalDateTime updatedAt;
+    private Long writerId;
+
+    protected Answer() {
+    }
 
     public Answer(User writer, Question question, String contents) {
         this(null, writer, question, contents);
@@ -90,4 +116,5 @@ public class Answer {
                 ", deleted=" + deleted +
                 '}';
     }
+
 }

--- a/src/main/java/qna/domain/AnswerRepository.java
+++ b/src/main/java/qna/domain/AnswerRepository.java
@@ -6,7 +6,8 @@ import java.util.List;
 import java.util.Optional;
 
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
-    List<Answer> findByQuestionIdAndDeletedFalse(Long questionId);
 
+    List<Answer> findByQuestionIdAndDeletedFalse(Long questionId);
     Optional<Answer> findByIdAndDeletedFalse(Long id);
+
 }

--- a/src/main/java/qna/domain/ContentType.java
+++ b/src/main/java/qna/domain/ContentType.java
@@ -1,5 +1,7 @@
 package qna.domain;
 
 public enum ContentType {
+
     QUESTION, ANSWER
+
 }

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -3,18 +3,57 @@ package qna.domain;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "delete_history")
 public class DeleteHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Enumerated(value = EnumType.STRING)
     private ContentType contentType;
+
     private Long contentId;
     private Long deletedById;
     private LocalDateTime createDate = LocalDateTime.now();
+
+    protected DeleteHistory() {
+    }
 
     public DeleteHistory(ContentType contentType, Long contentId, Long deletedById, LocalDateTime createDate) {
         this.contentType = contentType;
         this.contentId = contentId;
         this.deletedById = deletedById;
         this.createDate = createDate;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public ContentType getContentType() {
+        return contentType;
+    }
+
+    public Long getContentId() {
+        return contentId;
+    }
+
+    public Long getDeletedById() {
+        return deletedById;
+    }
+
+    public LocalDateTime getCreateDate() {
+        return createDate;
     }
 
     @Override
@@ -43,4 +82,5 @@ public class DeleteHistory {
                 ", createDate=" + createDate +
                 '}';
     }
+
 }

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -1,11 +1,40 @@
 package qna.domain;
 
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "question")
 public class Question {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private String title;
+
+    @Lob
     private String contents;
-    private Long writerId;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(nullable = false)
     private boolean deleted = false;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    private LocalDateTime updatedAt;
+    private Long writerId;
+
+    protected Question() {
+    }
 
     public Question(String title, String contents) {
         this(null, title, contents);
@@ -80,4 +109,5 @@ public class Question {
                 ", deleted=" + deleted +
                 '}';
     }
+
 }

--- a/src/main/java/qna/domain/QuestionRepository.java
+++ b/src/main/java/qna/domain/QuestionRepository.java
@@ -6,7 +6,9 @@ import java.util.List;
 import java.util.Optional;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
+
     List<Question> findByDeletedFalse();
 
     Optional<Question> findByIdAndDeletedFalse(Long id);
+
 }

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -2,18 +2,44 @@ package qna.domain;
 
 import qna.UnAuthorizedException;
 
+import java.time.LocalDateTime;
 import java.util.Objects;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "user")
 public class User {
+
     public static final GuestUser GUEST_USER = new GuestUser();
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private String userId;
-    private String password;
-    private String name;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(length = 50)
     private String email;
 
-    private User() {
+    @Column(nullable = false, length = 20)
+    private String name;
+
+    @Column(nullable = false, length = 20)
+    private String password;
+
+    private LocalDateTime updatedAt;
+
+    @Column(nullable = false, unique = true, length = 20)
+    private String userId;
+
+    protected User() {
     }
 
     public User(String userId, String password, String name, String email) {
@@ -119,4 +145,5 @@ public class User {
             return true;
         }
     }
+
 }

--- a/src/main/java/qna/domain/UserRepository.java
+++ b/src/main/java/qna/domain/UserRepository.java
@@ -5,5 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+
     Optional<User> findByUserId(String userId);
+
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,0 @@
-spring.datasource.url=jdbc:h2:~/test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-spring.datasource.username=sa

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    url: jdbc:h2:~/test;MODE=MySQL
+    username: sa
+
+  jpa:
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQL57Dialect
+    show-sql: true
+
+    hibernate:
+      ddl-auto: create

--- a/src/test/java/qna/domain/AnswerRepositoryTest.java
+++ b/src/test/java/qna/domain/AnswerRepositoryTest.java
@@ -1,0 +1,99 @@
+package qna.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DataJpaTest
+class AnswerRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    @Autowired
+    private AnswerRepository answerRepository;
+
+    private User savedWriter;
+    private Question savedQuestion;
+    private Answer answer;
+
+    @BeforeEach
+    void setUp() {
+        User writer = new User("tjdtls690", "abc1234@", "아벨", "tjdtls690@gmail.com");
+        savedWriter = userRepository.save(writer);
+        Question question = new Question("투표해야하는가?", "투표하세요");
+        savedQuestion = questionRepository.save(question);
+        answer = new Answer(savedWriter, savedQuestion, "투표했습니다");
+    }
+
+    @Test
+    void save() {
+        // when
+        Answer savedAnswer = answerRepository.save(answer);
+
+        // then
+        assertAll(
+                () -> assertThat(savedAnswer).isNotNull(),
+                () -> assertThat(savedAnswer.getWriterId()).isEqualTo(savedWriter.getId()),
+                () -> assertThat(savedAnswer.getQuestionId()).isEqualTo(savedQuestion.getId())
+        );
+    }
+
+    @Test
+    void findByQuestionIdAndDeletedFalse() {
+        // given
+        User writer = new User("tjdtls6901", "abc1234@", "아벨", "tjdtls690@gmail.com");
+        User savedWriter = userRepository.save(writer);
+        Question question = new Question("투표해야하는가?", "투표하세요");
+        Question savedQuestion = questionRepository.save(question);
+        Answer newAnswer = new Answer(savedWriter, savedQuestion, "투표했습니다");
+        newAnswer.setDeleted(true);
+
+        answerRepository.save(answer);
+        answerRepository.save(newAnswer);
+
+        // when
+        List<Answer> findAnswers = answerRepository.findByQuestionIdAndDeletedFalse(answer.getQuestionId());
+
+        // then
+        assertAll(
+                () -> assertThat(findAnswers).hasSize(1),
+                () -> assertThat(findAnswers.get(0)).usingRecursiveComparison().isEqualTo(answer)
+        );
+    }
+
+    @Test
+    void findAll() {
+        // given
+        User writer = new User("tjdtls6901", "abc1234@", "아벨", "tjdtls690@gmail.com");
+        User savedWriter = userRepository.save(writer);
+        Question question = new Question("투표해야하는가?", "투표하세요");
+        Question savedQuestion = questionRepository.save(question);
+        Answer newAnswer = new Answer(savedWriter, savedQuestion, "투표했습니다");
+
+        answerRepository.save(answer);
+        answerRepository.save(newAnswer);
+
+        // when
+        List<Answer> answers = answerRepository.findAll();
+
+        // then
+        assertAll(
+                () -> assertThat(answers).hasSize(2),
+                () -> assertThat(answers.get(0)).usingRecursiveComparison().isEqualTo(answer),
+                () -> assertThat(answers.get(1)).usingRecursiveComparison().isEqualTo(newAnswer)
+        );
+    }
+
+}

--- a/src/test/java/qna/domain/DeleteHistoryRepositoryTest.java
+++ b/src/test/java/qna/domain/DeleteHistoryRepositoryTest.java
@@ -1,0 +1,72 @@
+package qna.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DataJpaTest
+class DeleteHistoryRepositoryTest {
+
+    @Autowired
+    private DeleteHistoryRepository deleteHistoryRepository;
+
+    @Test
+    void save() {
+        // given
+        DeleteHistory deleteHistory = new DeleteHistory(ContentType.QUESTION, 1L, 1L, LocalDateTime.now());
+
+        // when
+        DeleteHistory savedDeleteHistory = deleteHistoryRepository.save(deleteHistory);
+
+        // then
+        assertAll(
+                () -> assertThat(savedDeleteHistory).isNotNull(),
+                () -> assertThat(savedDeleteHistory.getContentType()).isEqualTo(ContentType.QUESTION),
+                () -> assertThat(savedDeleteHistory.getContentId()).isEqualTo(1L),
+                () -> assertThat(savedDeleteHistory.getDeletedById()).isEqualTo(1L)
+        );
+    }
+
+    @Test
+    void findAll() {
+        // given
+        DeleteHistory deleteHistory1 = new DeleteHistory(ContentType.QUESTION, 1L, 1L, LocalDateTime.now());
+        DeleteHistory deleteHistory2 = new DeleteHistory(ContentType.ANSWER, 2L, 2L, LocalDateTime.now());
+
+        deleteHistoryRepository.save(deleteHistory1);
+        deleteHistoryRepository.save(deleteHistory2);
+
+        // when
+        List<DeleteHistory> deleteHistories = deleteHistoryRepository.findAll();
+
+        // then
+        assertAll(
+                () -> assertThat(deleteHistories).hasSize(2),
+                () -> assertThat(deleteHistories.get(0)).usingRecursiveComparison().isEqualTo(deleteHistory1),
+                () -> assertThat(deleteHistories.get(1)).usingRecursiveComparison().isEqualTo(deleteHistory2)
+        );
+    }
+
+    @Test
+    void delete() {
+        // given
+        DeleteHistory deleteHistory = new DeleteHistory(ContentType.QUESTION, 1L, 1L, LocalDateTime.now());
+        deleteHistoryRepository.save(deleteHistory);
+
+        // when
+        deleteHistoryRepository.delete(deleteHistory);
+
+        // then
+        List<DeleteHistory> deleteHistories = deleteHistoryRepository.findAll();
+        assertThat(deleteHistories).isEmpty();
+    }
+
+}

--- a/src/test/java/qna/domain/QuestionRepositoryTest.java
+++ b/src/test/java/qna/domain/QuestionRepositoryTest.java
@@ -1,0 +1,70 @@
+package qna.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DataJpaTest
+class QuestionRepositoryTest {
+
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    @Nested
+    class FindByIdAndDeleted {
+
+        @Test
+        void findByIdAndDeletedFalse() {
+            // given
+            Question question = new Question("나가", "응");
+            Question savedQuestion = questionRepository.save(question);
+
+            // when
+            Optional<Question> maybeQuestion = questionRepository.findByIdAndDeletedFalse(savedQuestion.getId());
+
+            // then
+            Question findQuestion = maybeQuestion.get();
+            assertAll(
+                    () -> assertThat(maybeQuestion).isNotNull(),
+                    () -> assertThat(findQuestion.getTitle()).isEqualTo("나가"),
+                    () -> assertThat(findQuestion.getContents()).isEqualTo("응")
+            );
+        }
+
+        @Test
+        void findByIdAndDeletedTrue() {
+            // given
+            Question question = new Question("나가", "응");
+            question.setDeleted(true);
+            Question savedQuestion = questionRepository.save(question);
+
+            // when
+            Optional<Question> maybeQuestion = questionRepository.findByIdAndDeletedFalse(savedQuestion.getId());
+
+            // then
+            assertThat(maybeQuestion).isEmpty();
+        }
+
+        @Test
+        void findByWrongIdAndDeletedFalse() {
+            // given
+            Long questionWrongId = -1L;
+
+            // when
+            Optional<Question> maybeQuestion = questionRepository.findByIdAndDeletedFalse(questionWrongId);
+
+            // then
+            assertThat(maybeQuestion).isEmpty();
+        }
+
+    }
+
+}

--- a/src/test/java/qna/domain/UserRepositoryTest.java
+++ b/src/test/java/qna/domain/UserRepositoryTest.java
@@ -1,0 +1,86 @@
+package qna.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DataJpaTest
+class UserRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void save() {
+        // given
+        User user = new User("tjdtls690", "abc1234@", "아벨", "tjdtls690@gmail.com");
+
+        // when
+        User savedUser = userRepository.save(user);
+
+        // then
+        assertAll(
+                () -> assertThat(savedUser).isNotNull(),
+                () -> assertThat(savedUser.getUserId()).isEqualTo("tjdtls690"),
+                () -> assertThat(savedUser.getPassword()).isEqualTo("abc1234@"),
+                () -> assertThat(savedUser.getName()).isEqualTo("아벨"),
+                () -> assertThat(savedUser.getEmail()).isEqualTo("tjdtls690@gmail.com")
+        );
+    }
+
+    @Test
+    void findAll() {
+        // given
+        User user1 = new User("tjdtls690", "abc1234@", "아벨", "tjdtls690@gmail.com");
+        User user2 = new User("aiaiaiai1", "abc1234!", "루쿠", "aiaiaiai1@gmail.com");
+        userRepository.save(user1);
+        userRepository.save(user2);
+
+        // when
+        List<User> users = userRepository.findAll();
+
+        // then
+        assertAll(
+                () -> assertThat(users).hasSize(2),
+                () -> assertThat(users.get(0)).usingRecursiveComparison().isEqualTo(user1),
+                () -> assertThat(users.get(1)).usingRecursiveComparison().isEqualTo(user2)
+        );
+    }
+
+    @Test
+    void update() {
+        // given
+        User user = new User("tjdtls690", "abc1234@", "아벨", "tjdtls690@gmail.com");
+        User savedUser = userRepository.save(user);
+        User loginUser = new User("tjdtls690", "abc1234@", "아벨", "tjdtls690@gmail.com");
+        User target = new User("tjdtls690", "abc1234@", "루쿠", "aiaiaiai1@gmail.com");
+
+        // when
+        savedUser.update(loginUser, target);
+
+        // then
+        User updatedUser = userRepository.findByUserId(savedUser.getUserId()).get();
+        assertThat(savedUser).usingRecursiveComparison().isEqualTo(updatedUser);
+    }
+
+    @Test
+    void delete() {
+        // given
+        User user = new User("tjdtls690", "abc1234@", "아벨", "tjdtls690@gmail.com");
+        userRepository.save(user);
+
+        // when
+        userRepository.delete(user);
+
+        // then
+        List<User> findUsers = userRepository.findAll();
+        assertThat(findUsers).isEmpty();
+    }
+
+}


### PR DESCRIPTION
안녕하세요 제이슨~! 
VoTogether 팀 루쿠, 아벨, 저문, 다즐 입니다.

1단계 엔티티 매핑 미션 제출합니다 😊

## 질문
현재 업데이트 테스트를 할 때, save -> changeQuantity -> findById 순으로 메서드를 호출하고 있습니다. 
저희는 실제 DB에 반영된 데이터에 대한 테스트를 하고 싶었습니다. 
그런데 findById로 찾게 되면 실제 update 쿼리가 나오지 않게 되는데, 이럴 때 어떻게 해야할까요??

저희가 생각한 방법은
1. EntityManager를 직접 사용해서 flush시키는 것
2. findByName 등의 식별자가 아닌 다른 컬럼으로 조회하는 것

2가지인데, 어떻게 생각하시나요?