### PR TITLE
[1단계 - 엔티티 매핑] 달리 미션 제출합니다

### DIFF
--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -1,28 +1,32 @@
 package qna.domain;
 
-import org.springframework.boot.autoconfigure.domain.EntityScan;
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.Table;
 import qna.NotFoundException;
 import qna.UnAuthorizedException;
 
-import javax.persistence.*;
-import java.time.LocalDateTime;
-import java.util.Date;
-import java.util.Objects;
-
 @Entity
-@Table(name ="answer")
-public class Answer extends QnaEntity{
+@Table(name = "answer")
+public class Answer extends QnaEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @Lob
     private String contents;
-    @Column(name = "deleted",nullable = false)
+    @Column(name = "deleted", nullable = false)
     private boolean deleted = false;
 
     private Long questionId;
     private Long writerId;
-    public Answer(){}
+
+    public Answer() {
+    }
 
     public Answer(User writer, Question question, String contents) {
         this(null, writer, question, contents);

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -1,16 +1,28 @@
 package qna.domain;
 
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 import qna.NotFoundException;
 import qna.UnAuthorizedException;
 
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.Date;
 import java.util.Objects;
 
-public class Answer {
+@Entity
+@Table(name ="answer")
+public class Answer extends QnaEntity{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private Long writerId;
-    private Long questionId;
+    @Lob
     private String contents;
+    @Column(name = "deleted",nullable = false)
     private boolean deleted = false;
+
+    private Long questionId;
+    private Long writerId;
+    public Answer(){}
 
     public Answer(User writer, Question question, String contents) {
         this(null, writer, question, contents);
@@ -41,7 +53,7 @@ public class Answer {
     }
 
     public Long getId() {
-        return id;
+        return this.id;
     }
 
     public void setId(Long id) {
@@ -83,7 +95,7 @@ public class Answer {
     @Override
     public String toString() {
         return "Answer{" +
-                "id=" + id +
+                "id=" + this.id +
                 ", writerId=" + writerId +
                 ", questionId=" + questionId +
                 ", contents='" + contents + '\'' +

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -25,7 +25,7 @@ public class Answer extends QnaEntity {
     private Long questionId;
     private Long writerId;
 
-    public Answer() {
+    protected Answer() {
     }
 
     public Answer(User writer, Question question, String contents) {

--- a/src/main/java/qna/domain/AnswerRepository.java
+++ b/src/main/java/qna/domain/AnswerRepository.java
@@ -1,9 +1,8 @@
 package qna.domain;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
     List<Answer> findByQuestionIdAndDeletedFalse(Long questionId);

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -1,12 +1,18 @@
 package qna.domain;
 
-import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.Objects;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
 
 @Entity
 @Table(name = "delete_history")
-public class DeleteHistory extends QnaEntity{
+public class DeleteHistory extends QnaEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -15,7 +21,9 @@ public class DeleteHistory extends QnaEntity{
     private ContentType contentType;
     private LocalDateTime createDate = LocalDateTime.now();
     private Long deletedById;
-    public DeleteHistory(){}
+
+    public DeleteHistory() {
+    }
 
     public DeleteHistory(ContentType contentType, Long contentId, Long deletedById, LocalDateTime createDate) {
         this.contentType = contentType;
@@ -26,8 +34,12 @@ public class DeleteHistory extends QnaEntity{
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         DeleteHistory that = (DeleteHistory) o;
         return Objects.equals(id, that.id) &&
                 contentType == that.contentType &&

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -1,14 +1,21 @@
 package qna.domain;
 
+import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
-public class DeleteHistory {
+@Entity
+@Table(name = "delete_history")
+public class DeleteHistory extends QnaEntity{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private ContentType contentType;
     private Long contentId;
-    private Long deletedById;
+    @Enumerated(EnumType.STRING)
+    private ContentType contentType;
     private LocalDateTime createDate = LocalDateTime.now();
+    private Long deletedById;
+    public DeleteHistory(){}
 
     public DeleteHistory(ContentType contentType, Long contentId, Long deletedById, LocalDateTime createDate) {
         this.contentType = contentType;

--- a/src/main/java/qna/domain/QnaEntity.java
+++ b/src/main/java/qna/domain/QnaEntity.java
@@ -1,0 +1,34 @@
+package qna.domain;
+
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public class QnaEntity {
+    @CreatedDate
+    @Column(nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt = LocalDateTime.now();
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/src/main/java/qna/domain/QnaEntity.java
+++ b/src/main/java/qna/domain/QnaEntity.java
@@ -2,14 +2,9 @@ package qna.domain;
 
 import java.time.LocalDateTime;
 import javax.persistence.Column;
-import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.MappedSuperclass;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -1,11 +1,17 @@
 package qna.domain;
 
-import javax.persistence.*;
 import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.Table;
 
 @Entity
 @Table(name = "question")
-public class Question extends QnaEntity{
+public class Question extends QnaEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -15,11 +21,14 @@ public class Question extends QnaEntity{
     private LocalDateTime createdAt = LocalDateTime.now();
     @Column(nullable = false)
     private boolean deleted = false;
-    @Column(nullable = false,length = 100)
+    @Column(nullable = false, length = 100)
     private String title;
     private LocalDateTime updatedAt = LocalDateTime.now();
     private Long writerId;
-    public Question(){}
+
+    public Question() {
+    }
+
     public Question(String title, String contents) {
         this(null, title, contents);
     }
@@ -48,7 +57,7 @@ public class Question extends QnaEntity{
     }
 
     public void setId(Long id) {
-         this.id = id;
+        this.id = id;
     }
 
     public String getTitle() {

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -1,12 +1,25 @@
 package qna.domain;
 
-public class Question {
-    private Long id;
-    private String title;
-    private String contents;
-    private Long writerId;
-    private boolean deleted = false;
+import javax.persistence.*;
+import java.time.LocalDateTime;
 
+@Entity
+@Table(name = "question")
+public class Question extends QnaEntity{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Lob
+    private String contents;
+    @Column(nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+    @Column(nullable = false)
+    private boolean deleted = false;
+    @Column(nullable = false,length = 100)
+    private String title;
+    private LocalDateTime updatedAt = LocalDateTime.now();
+    private Long writerId;
+    public Question(){}
     public Question(String title, String contents) {
         this(null, title, contents);
     }
@@ -35,7 +48,7 @@ public class Question {
     }
 
     public void setId(Long id) {
-        this.id = id;
+         this.id = id;
     }
 
     public String getTitle() {

--- a/src/main/java/qna/domain/QuestionRepository.java
+++ b/src/main/java/qna/domain/QuestionRepository.java
@@ -1,9 +1,8 @@
 package qna.domain;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
     List<Question> findByDeletedFalse();

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -1,16 +1,18 @@
 package qna.domain;
 
-import jdk.internal.logger.LocalizedLoggerWrapper;
-import org.springframework.transaction.annotation.Transactional;
-import qna.UnAuthorizedException;
-
-import javax.persistence.*;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import qna.UnAuthorizedException;
+
 @Entity
 @Table(name = "user")
-public class User extends QnaEntity{
+public class User extends QnaEntity {
     public static final GuestUser GUEST_USER = new GuestUser();
 
     @Id
@@ -20,12 +22,12 @@ public class User extends QnaEntity{
     private LocalDateTime createdAt = LocalDateTime.now();
     @Column(length = 50)
     private String email;
-    @Column(nullable = false,length = 20)
+    @Column(nullable = false, length = 20)
     private String name;
-    @Column(nullable = false,length = 20)
+    @Column(nullable = false, length = 20)
     private String password;
     private LocalDateTime updatedAt = LocalDateTime.now();
-    @Column(nullable = false,length = 20)
+    @Column(nullable = false, length = 20)
     private String userId;
 
     public User() {

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -1,19 +1,34 @@
 package qna.domain;
 
+import jdk.internal.logger.LocalizedLoggerWrapper;
+import org.springframework.transaction.annotation.Transactional;
 import qna.UnAuthorizedException;
 
+import javax.persistence.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Objects;
-
-public class User {
+@Entity
+@Table(name = "user")
+public class User extends QnaEntity{
     public static final GuestUser GUEST_USER = new GuestUser();
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private String userId;
-    private String password;
-    private String name;
+    @Column(nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+    @Column(length = 50)
     private String email;
+    @Column(nullable = false,length = 20)
+    private String name;
+    @Column(nullable = false,length = 20)
+    private String password;
+    private LocalDateTime updatedAt = LocalDateTime.now();
+    @Column(nullable = false,length = 20)
+    private String userId;
 
-    private User() {
+    public User() {
     }
 
     public User(String userId, String password, String name, String email) {

--- a/src/main/java/qna/domain/UserRepository.java
+++ b/src/main/java/qna/domain/UserRepository.java
@@ -1,8 +1,7 @@
 package qna.domain;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUserId(String userId);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,7 @@
 spring.datasource.url=jdbc:h2:~/test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 spring.datasource.username=sa
+
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.show-sql=true
+spring.jpa.hibernate.ddl-auto=create
+logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -1,6 +1,67 @@
 package qna.domain;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DataJpaTest
 public class AnswerTest {
     public static final Answer A1 = new Answer(UserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
     public static final Answer A2 = new Answer(UserTest.SANJIGI, QuestionTest.Q1, "Answers Contents2");
+    @Autowired
+    private AnswerRepository answers;
+
+    @Test
+    void save(){
+        // when
+        final Answer actual = answers.save(A1);
+
+        //then
+        assertThat(answers.findById(actual.getId()).get()).isEqualTo(actual);
+    }
+
+    @Test
+    void findById() {
+        // given
+        final long expected1 = answers.save(A1).getId();
+        final long expected2 = answers.save(A2).getId();
+
+        // when
+        final Answer actual1 = answers.findById(expected1).get();
+        final Answer actual2 = answers.findById(expected2).get();
+
+        // then
+        assertAll(
+                ()-> assertThat(actual1.getId()).isEqualTo(expected1),
+                ()-> assertThat(actual2.getId()).isEqualTo(expected2)
+        );
+    }
+
+    @Test
+    void update() {
+        // given
+        final Answer expected = answers.save(A1);
+
+        // when
+        expected.setContents("123123");
+
+        //then
+        assertThat(answers.findById(expected.getId()).get().getContents()).isEqualTo("123123");
+    }
+
+    @Test
+    void delete() {
+        // given
+        final Answer expected = answers.save(A1);
+
+        // when
+        answers.delete(expected);
+
+        //then
+        assertThat(answers.findById(expected.getId()).isPresent()).isFalse();
+    }
 }

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -1,12 +1,11 @@
 package qna.domain;
 
-import org.junit.jupiter.api.DisplayName;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DataJpaTest
 public class AnswerTest {
@@ -16,7 +15,7 @@ public class AnswerTest {
     private AnswerRepository answers;
 
     @Test
-    void save(){
+    void save() {
         // when
         final Answer actual = answers.save(A1);
 
@@ -36,8 +35,8 @@ public class AnswerTest {
 
         // then
         assertAll(
-                ()-> assertThat(actual1.getId()).isEqualTo(expected1),
-                ()-> assertThat(actual2.getId()).isEqualTo(expected2)
+                () -> assertThat(actual1.getId()).isEqualTo(expected1),
+                () -> assertThat(actual2.getId()).isEqualTo(expected2)
         );
     }
 

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -1,6 +1,68 @@
 package qna.domain;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
 public class QuestionTest {
     public static final Question Q1 = new Question("title1", "contents1").writeBy(UserTest.JAVAJIGI);
     public static final Question Q2 = new Question("title2", "contents2").writeBy(UserTest.SANJIGI);
+
+    @Autowired
+    private QuestionRepository questions;
+
+    @Test
+    void save() {
+        // when
+        final Question expected = questions.save(Q1);
+
+        //then
+        assertThat(questions.findById(expected.getId()).get()).isEqualTo(expected);
+    }
+
+    @Test
+    void update() {
+        // given
+        final Question expected = questions.save(Q1);
+
+        // when
+        expected.setContents("123123");
+
+        //then
+        assertThat(questions.findById(expected.getId()).get().getContents()).isEqualTo("123123");
+    }
+
+    @Test
+    void find() {
+        // given
+        final Question question1 = questions.save(Q1);
+        final Question question2 = questions.save(Q2);
+
+        // when
+        final Question actual1 = questions.findById(question1.getId()).get();
+        final Question actual2 = questions.findById(question2.getId()).get();
+
+        //then
+        assertAll(
+                ()->assertThat(actual1).isEqualTo(question1),
+                ()->assertThat(actual2).isEqualTo(question2)
+        );
+    }
+
+    @Test
+    void delete() {
+        // given
+        final Question expected =questions.save(Q1);
+
+        // when
+        questions.delete(expected);
+
+        //then
+        assertThat(questions.findById(expected.getId()).isPresent()).isFalse();
+    }
 }

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -3,7 +3,6 @@ package qna.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -49,15 +48,15 @@ public class QuestionTest {
 
         //then
         assertAll(
-                ()->assertThat(actual1).isEqualTo(question1),
-                ()->assertThat(actual2).isEqualTo(question2)
+                () -> assertThat(actual1).isEqualTo(question1),
+                () -> assertThat(actual2).isEqualTo(question2)
         );
     }
 
     @Test
     void delete() {
         // given
-        final Question expected =questions.save(Q1);
+        final Question expected = questions.save(Q1);
 
         // when
         questions.delete(expected);

--- a/src/test/java/qna/domain/UserTest.java
+++ b/src/test/java/qna/domain/UserTest.java
@@ -3,7 +3,6 @@ package qna.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -15,6 +14,7 @@ public class UserTest {
 
     @Autowired
     private UserRepository users;
+
     @Test
     void save() {
         // when
@@ -36,8 +36,8 @@ public class UserTest {
 
         //then
         assertAll(
-                ()->assertThat(actual1).isEqualTo(expected1),
-                ()->assertThat(actual2).isEqualTo(expected2)
+                () -> assertThat(actual1).isEqualTo(expected1),
+                () -> assertThat(actual2).isEqualTo(expected2)
         );
     }
 

--- a/src/test/java/qna/domain/UserTest.java
+++ b/src/test/java/qna/domain/UserTest.java
@@ -1,6 +1,67 @@
 package qna.domain;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
 public class UserTest {
     public static final User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
     public static final User SANJIGI = new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
+
+    @Autowired
+    private UserRepository users;
+    @Test
+    void save() {
+        // when
+        final User expected = users.save(JAVAJIGI);
+
+        //then
+        assertThat(users.findById(expected.getId()).get()).isEqualTo(expected);
+    }
+
+    @Test
+    void find() {
+        // given
+        final User expected1 = users.save(JAVAJIGI);
+        final User expected2 = users.save(SANJIGI);
+
+        // when
+        final User actual1 = users.findById(expected1.getId()).get();
+        final User actual2 = users.findById(expected2.getId()).get();
+
+        //then
+        assertAll(
+                ()->assertThat(actual1).isEqualTo(expected1),
+                ()->assertThat(actual2).isEqualTo(expected2)
+        );
+    }
+
+    @Test
+    void update() {
+        // given
+        final User expected = users.save(JAVAJIGI);
+
+        // when
+        expected.setEmail("123@123");
+
+        //then
+        assertThat(users.findById(expected.getId()).get().getEmail()).isEqualTo("123@123");
+    }
+
+    @Test
+    void delete() {
+        // given
+        final User expected = users.save(JAVAJIGI);
+
+        // when
+        users.delete(expected);
+
+        //then
+        assertThat(users.findById(expected.getId()).isPresent()).isFalse();
+    }
 }


### PR DESCRIPTION
안녕하십니까!

행복을 기록하다! 행록의 달리입니다.

이번 jpa 미션을 진행하면서 생긴 궁금증 몇개 적어봅니다!

1. createdAt 이나 updatedAt과 같이 공통적으로 있는 column에 의해 QnaEntity라는 부모 entity를 만들었습니다. 이 과정에서 id도 공통되게 long값을 사용하여 넣어둘려고 하였으나 equals나 toString같은 메서드에서 id가 사용되면서 protected 키워드로 바꾸면 캡슐화가 깨진다는 생각에 넣지 않게 되었습니다. 이에대한 제이슨의 생각이 궁금합니다.
2. 각 엔티티의 save를 테스트 하면서 db에 제대로 저장이 되었는지를 확인하는 것이 중요하다고 생각하여 
```java
        final Answer actual = answers.save(A1);

        //then
        assertThat(answers.findById(actual.getId()).get()).isEqualTo(actual);
```
다음과 같이 진행하였습니다. 근데 이게 actual로 actual을 확인하는 것인지 아니면 findById를 테스트 하는 것인지 뭔가 꼬이는 느낌이 들었습니다. 
```java
        final Answer actual = answers.save(A1);

        //then
        assertThat(answers.findById(actual.getId()).get()).isEqualTo(A1);
```
을 하였지만 전체 테스트 진행시(다른 메서드 포함) delete에 의해 autoincreament가 증가하면서 id값이 바뀌어 기존 테스트에서 생성한 A1의 아이디 값과 save함수를 통해 넣은 아이디 값에 차이가 생겼습니다. 물론 column에 있는 delete로 보아 추측하는데 삭제시 상태를 변경하도록 유도해야 하는 것 같지만 다른 경우 delete를 사용할때 매 테스트별 autoincreament가 초기화가 되지 않는 문제를 해결할 좋은 방법이 있을까요?