### PR TITLE
👊🏾 스탬프크러쉬 2단계 제출! 연관관계 매핑 😎

### DIFF
--- a/src/main/java/qna/Application.java
+++ b/src/main/java/qna/Application.java
@@ -2,7 +2,9 @@ package qna;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class Application {
     public static void main(String[] args) {

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -19,9 +19,15 @@ public class Answer extends BaseDate {
     @Column(nullable = false)
     private boolean deleted = false;
 
-    private Long questionId;
+    @ManyToOne
+    @JoinColumn(name = "question_id",
+            foreignKey = @ForeignKey(name = "fk_answer_to_question"))
+    private Question question;
 
-    private Long writerId;
+    @ManyToOne
+    @JoinColumn(name = "writer_id",
+            foreignKey = @ForeignKey(name = "fk_answer_writer"))
+    private User writer;
 
     protected Answer() {
     }
@@ -41,17 +47,13 @@ public class Answer extends BaseDate {
             throw new NotFoundException();
         }
 
-        this.writerId = writer.getId();
-        this.questionId = question.getId();
+        this.writer = writer;
+        this.question = question;
         this.contents = contents;
     }
 
     public boolean isOwner(User writer) {
-        return this.writerId.equals(writer.getId());
-    }
-
-    public void toQuestion(Question question) {
-        this.questionId = question.getId();
+        return this.writer.equals(writer);
     }
 
     public Long getId() {
@@ -60,22 +62,6 @@ public class Answer extends BaseDate {
 
     public void setId(Long id) {
         this.id = id;
-    }
-
-    public Long getWriterId() {
-        return writerId;
-    }
-
-    public void setWriterId(Long writerId) {
-        this.writerId = writerId;
-    }
-
-    public Long getQuestionId() {
-        return questionId;
-    }
-
-    public void setQuestionId(Long questionId) {
-        this.questionId = questionId;
     }
 
     public String getContents() {
@@ -94,14 +80,19 @@ public class Answer extends BaseDate {
         this.deleted = deleted;
     }
 
-    @Override
-    public String toString() {
-        return "Answer{" +
-                "id=" + id +
-                ", writerId=" + writerId +
-                ", questionId=" + questionId +
-                ", contents='" + contents + '\'' +
-                ", deleted=" + deleted +
-                '}';
+    public Question getQuestion() {
+        return question;
+    }
+
+    public void setQuestion(Question question) {
+        this.question = question;
+    }
+
+    public User getWriter() {
+        return writer;
+    }
+
+    public void setWriter(User writer) {
+        this.writer = writer;
     }
 }

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -4,11 +4,10 @@ import qna.NotFoundException;
 import qna.UnAuthorizedException;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Entity
-public class Answer {
+public class Answer extends BaseDate {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -17,14 +16,9 @@ public class Answer {
     @Lob
     private String contents;
 
-    @Column(nullable = false)
-    private LocalDateTime createdAt = LocalDateTime.now();
-
     private boolean deleted = false;
 
     private Long questionId;
-
-    private LocalDateTime updatedAt;
 
     private Long writerId;
 

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -16,6 +16,7 @@ public class Answer extends BaseDate {
     @Lob
     private String contents;
 
+    @Column(nullable = false)
     private boolean deleted = false;
 
     private Long questionId;
@@ -44,7 +45,6 @@ public class Answer extends BaseDate {
         this.questionId = question.getId();
         this.contents = contents;
     }
-
 
     public boolean isOwner(User writer) {
         return this.writerId.equals(writer.getId());

--- a/src/main/java/qna/domain/BaseDate.java
+++ b/src/main/java/qna/domain/BaseDate.java
@@ -1,0 +1,22 @@
+package qna.domain;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseDate {
+
+    @CreatedDate
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -1,10 +1,14 @@
 package qna.domain;
 
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
 import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 public class DeleteHistory {
 
     @Id
@@ -16,7 +20,9 @@ public class DeleteHistory {
     @Enumerated(EnumType.STRING)
     private ContentType contentType;
 
-    private LocalDateTime createDate = LocalDateTime.now();
+    @Column(nullable = false)
+    @CreatedDate
+    private LocalDateTime createDate;
 
     @ManyToOne
     @JoinColumn(name = "deleted_by_id",

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -18,15 +18,18 @@ public class DeleteHistory {
 
     private LocalDateTime createDate = LocalDateTime.now();
 
-    private Long deletedById;
+    @ManyToOne
+    @JoinColumn(name = "deleted_by_id",
+            foreignKey = @ForeignKey(name = "fk_delete_history_to_user"))
+    private User deletedBy;
 
     protected DeleteHistory() {
     }
 
-    public DeleteHistory(ContentType contentType, Long contentId, Long deletedById, LocalDateTime createDate) {
+    public DeleteHistory(ContentType contentType, Long contentId, User deletedBy, LocalDateTime createDate) {
         this.contentType = contentType;
         this.contentId = contentId;
-        this.deletedById = deletedById;
+        this.deletedBy = deletedBy;
         this.createDate = createDate;
     }
 
@@ -35,25 +38,11 @@ public class DeleteHistory {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         DeleteHistory that = (DeleteHistory) o;
-        return Objects.equals(id, that.id) &&
-                contentType == that.contentType &&
-                Objects.equals(contentId, that.contentId) &&
-                Objects.equals(deletedById, that.deletedById);
+        return Objects.equals(id, that.id) && Objects.equals(contentId, that.contentId) && contentType == that.contentType && Objects.equals(createDate, that.createDate) && Objects.equals(deletedBy, that.deletedBy);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, contentType, contentId, deletedById);
-    }
-
-    @Override
-    public String toString() {
-        return "DeleteHistory{" +
-                "id=" + id +
-                ", contentType=" + contentType +
-                ", contentId=" + contentId +
-                ", deletedById=" + deletedById +
-                ", createDate=" + createDate +
-                '}';
+        return Objects.hash(id, contentId, contentType, createDate, deletedBy);
     }
 }

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -41,6 +41,12 @@ public class Question extends BaseDate {
         this.contents = contents;
     }
 
+    public Question(String contents, String title, User writer) {
+        this.contents = contents;
+        this.title = title;
+        this.writer = writer;
+    }
+
     public Question writeBy(User writer) {
         this.writer = writer;
         return this;

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -1,6 +1,8 @@
 package qna.domain;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 public class Question extends BaseDate {
@@ -18,7 +20,13 @@ public class Question extends BaseDate {
     @Column(length = 100, nullable = false)
     private String title;
 
-    private Long writerId;
+    @ManyToOne
+    @JoinColumn(name = "writer_id",
+            foreignKey = @ForeignKey(name = "fk_question_writer"))
+    private User writer;
+
+    @OneToMany(mappedBy = "question")
+    private List<Answer> answers = new ArrayList<>();
 
     protected Question() {
     }
@@ -34,16 +42,21 @@ public class Question extends BaseDate {
     }
 
     public Question writeBy(User writer) {
-        this.writerId = writer.getId();
+        this.writer = writer;
         return this;
     }
 
     public boolean isOwner(User writer) {
-        return this.writerId.equals(writer.getId());
+        return this.writer.equals(writer.getId());
     }
 
     public void addAnswer(Answer answer) {
-        answer.toQuestion(this);
+        answers.add(answer);
+        answer.setQuestion(this);
+    }
+
+    public List<Answer> getAnswers() {
+        return new ArrayList<>(answers);
     }
 
     public Long getId() {
@@ -54,28 +67,12 @@ public class Question extends BaseDate {
         this.id = id;
     }
 
-    public String getTitle() {
-        return title;
-    }
-
-    public void setTitle(String title) {
-        this.title = title;
-    }
-
     public String getContents() {
         return contents;
     }
 
     public void setContents(String contents) {
         this.contents = contents;
-    }
-
-    public Long getWriterId() {
-        return writerId;
-    }
-
-    public void setWriterId(Long writerId) {
-        this.writerId = writerId;
     }
 
     public boolean isDeleted() {
@@ -86,13 +83,29 @@ public class Question extends BaseDate {
         this.deleted = deleted;
     }
 
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public User getWriter() {
+        return writer;
+    }
+
+    public void setWriter(User writer) {
+        this.writer = writer;
+    }
+
     @Override
     public String toString() {
         return "Question{" +
                 "id=" + id +
                 ", title='" + title + '\'' +
                 ", contents='" + contents + '\'' +
-                ", writerId=" + writerId +
+                ", writer=" + writer +
                 ", deleted=" + deleted +
                 '}';
     }

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -1,10 +1,9 @@
 package qna.domain;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 
 @Entity
-public class Question {
+public class Question extends BaseDate {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -14,15 +13,10 @@ public class Question {
     private String contents;
 
     @Column(nullable = false)
-    private LocalDateTime createdAt = LocalDateTime.now();
-
-    @Column(nullable = false)
     private boolean deleted = false;
 
     @Column(length = 100, nullable = false)
     private String title;
-
-    private LocalDateTime updatedAt;
 
     private Long writerId;
 

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -3,20 +3,16 @@ package qna.domain;
 import qna.UnAuthorizedException;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Entity
-public class User {
+public class User extends BaseDate {
 
     public static final GuestUser GUEST_USER = new GuestUser();
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    @Column(nullable = false)
-    private LocalDateTime createdAt = LocalDateTime.now();
 
     @Column(length = 50)
     private String email;
@@ -26,8 +22,6 @@ public class User {
 
     @Column(length = 20, nullable = false)
     private String password;
-
-    private LocalDateTime updatedAt;
 
     @Column(length = 20, nullable = false, unique = true)
     private String userId;

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -132,4 +132,17 @@ public class User extends BaseDate {
             return true;
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        User user = (User) o;
+        return Objects.equals(id, user.id) && Objects.equals(email, user.email) && Objects.equals(name, user.name) && Objects.equals(password, user.password) && Objects.equals(userId, user.userId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, email, name, password, userId);
+    }
 }

--- a/src/main/java/qna/service/QnaService.java
+++ b/src/main/java/qna/service/QnaService.java
@@ -48,10 +48,10 @@ public class QnaService {
 
         List<DeleteHistory> deleteHistories = new ArrayList<>();
         question.setDeleted(true);
-        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriterId(), LocalDateTime.now()));
+        deleteHistories.add(new DeleteHistory(ContentType.QUESTION, questionId, question.getWriter(), LocalDateTime.now()));
         for (Answer answer : answers) {
             answer.setDeleted(true);
-            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriterId(), LocalDateTime.now()));
+            deleteHistories.add(new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now()));
         }
         deleteHistoryService.saveAll(deleteHistories);
     }

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -8,7 +8,6 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static qna.domain.QuestionTest.Q1;
 import static qna.fixture.UserFixture.JAVAJIGI;
 import static qna.fixture.UserFixture.SANJIGI;
 
@@ -32,7 +31,7 @@ public class AnswerTest {
         User user1 = userRepository.save(JAVAJIGI);
         User user2 = userRepository.save(SANJIGI);
 
-        Question question = questionRepository.save(Q1.writeBy(user1));
+        Question question = questionRepository.save(new Question("title1", "contents1").writeBy(user1));
 
         A1 = new Answer(user1, question, "Answers Contents1");
         A2 = new Answer(user2, question, "Answers Contents2");

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -65,4 +65,15 @@ public class AnswerTest {
         // then
         assertThat(findAnswer).isEqualTo(savedAnswer);
     }
+
+    @Test
+    void Question을_조회한다() {
+        // given, when
+        Answer savedAnswer = answerRepository.save(A1);
+
+        Question question = savedAnswer.getQuestion();
+
+        // then
+        assertThat(question.getTitle()).isEqualTo("title1");
+    }
 }

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -1,5 +1,6 @@
 package qna.domain;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -7,15 +8,35 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static qna.domain.QuestionTest.Q1;
+import static qna.domain.UserTest.JAVAJIGI;
+import static qna.domain.UserTest.SANJIGI;
 
 @DataJpaTest
 public class AnswerTest {
 
+    private Answer A1;
+    private Answer A2;
+
     @Autowired
     private AnswerRepository answerRepository;
 
-    public static final Answer A1 = new Answer(UserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
-    public static final Answer A2 = new Answer(UserTest.SANJIGI, QuestionTest.Q1, "Answers Contents2");
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @BeforeEach
+    void setUp() {
+        User user1 = userRepository.save(JAVAJIGI);
+        User user2 = userRepository.save(SANJIGI);
+
+        Question question = questionRepository.save(Q1.writeBy(user1));
+
+        A1 = new Answer(user1, question, "Answers Contents1");
+        A2 = new Answer(user2, question, "Answers Contents2");
+    }
 
     @Test
     void 답변을_저장한다() {

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -9,8 +9,8 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static qna.domain.QuestionTest.Q1;
-import static qna.domain.UserTest.JAVAJIGI;
-import static qna.domain.UserTest.SANJIGI;
+import static qna.fixture.UserFixture.JAVAJIGI;
+import static qna.fixture.UserFixture.SANJIGI;
 
 @DataJpaTest
 public class AnswerTest {

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -1,15 +1,12 @@
 package qna.domain;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DataJpaTest
 public class AnswerTest {

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -15,21 +15,21 @@ import static qna.fixture.UserFixture.SANJIGI;
 @DataJpaTest
 public class QuestionTest {
 
-    public static final Question Q1 = new Question("title1", "contents1");
-    public static final Question Q2 = new Question("title2", "contents2");
-
     @Autowired
     private QuestionRepository questionRepository;
 
     @Autowired
     private UserRepository userRepository;
 
+    private Question Q1;
+    private Question Q2;
+
     @BeforeEach
     void setUp() {
         User user1 = userRepository.save(JAVAJIGI);
-        Q1.writeBy(user1);
+        Q1 = new Question("title1", "contents1", user1);
         User user2 = userRepository.save(SANJIGI);
-        Q2.writeBy(user2);
+        Q2 = new Question("title2", "contents2", user2);
     }
 
     @Test

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -21,14 +21,20 @@ public class QuestionTest {
     @Autowired
     private UserRepository userRepository;
 
+    @Autowired
+    private AnswerRepository answerRepository;
+
     private Question Q1;
     private Question Q2;
 
+    private User user1;
+    private User user2;
+
     @BeforeEach
     void setUp() {
-        User user1 = userRepository.save(JAVAJIGI);
+        user1 = userRepository.save(JAVAJIGI);
         Q1 = new Question("title1", "contents1", user1);
-        User user2 = userRepository.save(SANJIGI);
+        user2 = userRepository.save(SANJIGI);
         Q2 = new Question("title2", "contents2", user2);
     }
 
@@ -61,5 +67,21 @@ public class QuestionTest {
 
         // then
         AssertionsForClassTypes.assertThat(savedQuestion).isEqualTo(findQuestion);
+    }
+
+    @Test
+    void Answer_목록을_조회한다() {
+        // given, when
+        Question question = questionRepository.save(Q1);
+        Answer A1 = new Answer(user1, question, "Answers Contents1");
+        Answer A2 = new Answer(user2, question, "Answers Contents2");
+        Answer savedA1 = answerRepository.save(A1);
+        Answer savedA2 = answerRepository.save(A2);
+
+        question.addAnswer(savedA1);
+        question.addAnswer(savedA2);
+
+        // then
+        assertThat(question.getAnswers()).containsExactlyInAnyOrder(savedA1, savedA2);
     }
 }

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -9,6 +9,8 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static qna.fixture.UserFixture.JAVAJIGI;
+import static qna.fixture.UserFixture.SANJIGI;
 
 @DataJpaTest
 public class QuestionTest {
@@ -24,9 +26,9 @@ public class QuestionTest {
 
     @BeforeEach
     void setUp() {
-        User user1 = userRepository.save(UserTest.JAVAJIGI);
+        User user1 = userRepository.save(JAVAJIGI);
         Q1.writeBy(user1);
-        User user2 = userRepository.save(UserTest.SANJIGI);
+        User user2 = userRepository.save(SANJIGI);
         Q2.writeBy(user2);
     }
 

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -1,6 +1,7 @@
 package qna.domain;
 
 import org.assertj.core.api.AssertionsForClassTypes;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -12,11 +13,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DataJpaTest
 public class QuestionTest {
 
-    public static final Question Q1 = new Question("title1", "contents1").writeBy(UserTest.JAVAJIGI);
-    public static final Question Q2 = new Question("title2", "contents2").writeBy(UserTest.SANJIGI);
+    public static final Question Q1 = new Question("title1", "contents1");
+    public static final Question Q2 = new Question("title2", "contents2");
 
     @Autowired
     private QuestionRepository questionRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @BeforeEach
+    void setUp() {
+        User user1 = userRepository.save(UserTest.JAVAJIGI);
+        Q1.writeBy(user1);
+        User user2 = userRepository.save(UserTest.SANJIGI);
+        Q2.writeBy(user2);
+    }
 
     @Test
     void 질문을_저장한다() {
@@ -48,5 +60,4 @@ public class QuestionTest {
         // then
         AssertionsForClassTypes.assertThat(savedQuestion).isEqualTo(findQuestion);
     }
-
 }

--- a/src/test/java/qna/domain/UserTest.java
+++ b/src/test/java/qna/domain/UserTest.java
@@ -7,12 +7,11 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static qna.fixture.UserFixture.JAVAJIGI;
+import static qna.fixture.UserFixture.SANJIGI;
 
 @DataJpaTest
 public class UserTest {
-
-    public static final User JAVAJIGI = new User("javajigi", "password", "name", "javajigi@slipp.net");
-    public static final User SANJIGI = new User("sanjigi", "password", "name", "sanjigi@slipp.net");
 
     @Autowired
     private UserRepository userRepository;

--- a/src/test/java/qna/fixture/UserFixture.java
+++ b/src/test/java/qna/fixture/UserFixture.java
@@ -1,0 +1,9 @@
+package qna.fixture;
+
+import qna.domain.User;
+
+public class UserFixture {
+
+    public static final User JAVAJIGI = new User("javajigi", "password", "name", "javajigi@slipp.net");
+    public static final User SANJIGI = new User("sanjigi", "password", "name", "sanjigi@slipp.net");
+}

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -1,6 +1,7 @@
 package qna.service;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -19,8 +20,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@Disabled
 @ExtendWith(MockitoExtension.class)
 class QnaServiceTest {
+
     @Mock
     private QuestionRepository questionRepository;
 
@@ -89,8 +92,8 @@ class QnaServiceTest {
 
     private void verifyDeleteHistories() {
         List<DeleteHistory> deleteHistories = Arrays.asList(
-                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriterId(), LocalDateTime.now()),
-                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriterId(), LocalDateTime.now())
+                new DeleteHistory(ContentType.QUESTION, question.getId(), question.getWriter(), LocalDateTime.now()),
+                new DeleteHistory(ContentType.ANSWER, answer.getId(), answer.getWriter(), LocalDateTime.now())
         );
         verify(deleteHistoryService).saveAll(deleteHistories);
     }

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -19,6 +19,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static qna.fixture.UserFixture.JAVAJIGI;
+import static qna.fixture.UserFixture.SANJIGI;
 
 @Disabled
 @ExtendWith(MockitoExtension.class)
@@ -41,8 +43,8 @@ class QnaServiceTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        question = new Question(1L, "title1", "contents1").writeBy(UserTest.JAVAJIGI);
-        answer = new Answer(1L, UserTest.JAVAJIGI, question, "Answers Contents1");
+        question = new Question(1L, "title1", "contents1").writeBy(JAVAJIGI);
+        answer = new Answer(1L, JAVAJIGI, question, "Answers Contents1");
         question.addAnswer(answer);
     }
 
@@ -52,7 +54,7 @@ class QnaServiceTest {
         when(answerRepository.findByQuestionIdAndDeletedFalse(question.getId())).thenReturn(Arrays.asList(answer));
 
         assertThat(question.isDeleted()).isFalse();
-        qnaService.deleteQuestion(UserTest.JAVAJIGI, question.getId());
+        qnaService.deleteQuestion(JAVAJIGI, question.getId());
 
         assertThat(question.isDeleted()).isTrue();
         verifyDeleteHistories();
@@ -62,7 +64,7 @@ class QnaServiceTest {
     public void delete_다른_사람이_쓴_글() throws Exception {
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
 
-        assertThatThrownBy(() -> qnaService.deleteQuestion(UserTest.SANJIGI, question.getId()))
+        assertThatThrownBy(() -> qnaService.deleteQuestion(SANJIGI, question.getId()))
                 .isInstanceOf(CannotDeleteException.class);
     }
 
@@ -71,7 +73,7 @@ class QnaServiceTest {
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
         when(answerRepository.findByQuestionIdAndDeletedFalse(question.getId())).thenReturn(Arrays.asList(answer));
 
-        qnaService.deleteQuestion(UserTest.JAVAJIGI, question.getId());
+        qnaService.deleteQuestion(JAVAJIGI, question.getId());
 
         assertThat(question.isDeleted()).isTrue();
         assertThat(answer.isDeleted()).isTrue();
@@ -80,13 +82,13 @@ class QnaServiceTest {
 
     @Test
     public void delete_답변_중_다른_사람이_쓴_글() throws Exception {
-        Answer answer2 = new Answer(2L, UserTest.SANJIGI, QuestionTest.Q1, "Answers Contents1");
+        Answer answer2 = new Answer(2L, SANJIGI, QuestionTest.Q1, "Answers Contents1");
         question.addAnswer(answer2);
 
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));
         when(answerRepository.findByQuestionIdAndDeletedFalse(question.getId())).thenReturn(Arrays.asList(answer, answer2));
 
-        assertThatThrownBy(() -> qnaService.deleteQuestion(UserTest.JAVAJIGI, question.getId()))
+        assertThatThrownBy(() -> qnaService.deleteQuestion(JAVAJIGI, question.getId()))
                 .isInstanceOf(CannotDeleteException.class);
     }
 

--- a/src/test/java/qna/service/QnaServiceTest.java
+++ b/src/test/java/qna/service/QnaServiceTest.java
@@ -82,7 +82,7 @@ class QnaServiceTest {
 
     @Test
     public void delete_답변_중_다른_사람이_쓴_글() throws Exception {
-        Answer answer2 = new Answer(2L, SANJIGI, QuestionTest.Q1, "Answers Contents1");
+        Answer answer2 = new Answer(2L, SANJIGI, new Question("title1", "contents1"), "Answers Contents1");
         question.addAnswer(answer2);
 
         when(questionRepository.findByIdAndDeletedFalse(question.getId())).thenReturn(Optional.of(question));


### PR DESCRIPTION
안녕하세요 스탬프크러쉬입니다.
2단계 PR 제출합니다.

## 질문

#### `DeleteHistory`의 `content_id`가 `Answer`가 될 수도 있고, `Question`이 될 수도 있는데, 이 두 가지를 추상화한 클래스를 만드는 것이 좋을지, 단지 id를 넣어놓는 것이 좋을지 고민입니다! 

두 가지를 추상화한 클래스를 만드는 경우, 부모 객체를 직접 매핑해 놓으면 참조를 곧바로 사용할 수 있겠지만, 아직 삭제 이력에서 직접 컨텐츠를 조회해야 할 필요가 크게 느껴지지 않아서 id로 매핑해 놓은 상황입니다. 

삭제를 한 후에 객체를 참조해서 추가적인 작업을 하게 될 것 같지 않을 것 같다고 생각했습니다. 

#### `DeleteHistory`에서 별도로 `deleted_by_id`가 존재하는 이유에 대해

우리 팀은 `Question`을 지울 경우에 `Answer`가 함께 지워지는 상황을 고려하여, `Answer`의 경우에 삭제한 사람과 작성자가 다른 경우에 이를 구분하기 위해서라고 생각했습니다. 이 의도가 맞는지 궁금합니다!_!_! 혹은, 관리자가 삭제하는 경우를 구분하기 위한 것인지에 대해서가 궁금합니다! 
