### PR TITLE
[1단계 - 엔티티 매핑] 나아가팀 미션 제출합니다

### DIFF
--- a/src/main/java/qna/Application.java
+++ b/src/main/java/qna/Application.java
@@ -2,7 +2,9 @@ package qna;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class Application {
     public static void main(String[] args) {

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -13,11 +13,19 @@ import java.util.Objects;
 public class Answer {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private Long writerId;
     private Long questionId;
+    @Lob
     private String contents;
+    @Column(nullable = false)
     private boolean deleted = false;
+    @CreationTimestamp
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
 
     protected Answer() {
     }

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -1,31 +1,27 @@
 package qna.domain;
 
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
 import qna.NotFoundException;
 import qna.UnAuthorizedException;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Entity
-public class Answer {
+public class Answer extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     private Long writerId;
+
     private Long questionId;
+
     @Lob
     private String contents;
-    @Column(nullable = false)
-    private boolean deleted = false;
-    @CreationTimestamp
-    @Column(nullable = false)
-    private LocalDateTime createdAt;
-    @UpdateTimestamp
-    private LocalDateTime updatedAt;
+
+    @Column(nullable = false) // ddl 관련
+    private boolean deleted = false; // 이건 객체 관점
 
     protected Answer() {
     }

--- a/src/main/java/qna/domain/Answer.java
+++ b/src/main/java/qna/domain/Answer.java
@@ -1,16 +1,26 @@
 package qna.domain;
 
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 import qna.NotFoundException;
 import qna.UnAuthorizedException;
 
+import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.Objects;
 
+@Entity
 public class Answer {
+
+    @Id
     private Long id;
     private Long writerId;
     private Long questionId;
     private String contents;
     private boolean deleted = false;
+
+    protected Answer() {
+    }
 
     public Answer(User writer, Question question, String contents) {
         this(null, writer, question, contents);

--- a/src/main/java/qna/domain/AnswerRepository.java
+++ b/src/main/java/qna/domain/AnswerRepository.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
+
     List<Answer> findByQuestionIdAndDeletedFalse(Long questionId);
 
     Optional<Answer> findByIdAndDeletedFalse(Long id);

--- a/src/main/java/qna/domain/BaseEntity.java
+++ b/src/main/java/qna/domain/BaseEntity.java
@@ -1,0 +1,31 @@
+package qna.domain;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}
+

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -1,14 +1,21 @@
 package qna.domain;
 
+import javax.persistence.Entity;
+import javax.persistence.Id;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
+@Entity
 public class DeleteHistory {
+    @Id
     private Long id;
     private ContentType contentType;
     private Long contentId;
     private Long deletedById;
     private LocalDateTime createDate = LocalDateTime.now();
+
+    protected DeleteHistory() {
+    }
 
     public DeleteHistory(ContentType contentType, Long contentId, Long deletedById, LocalDateTime createDate) {
         this.contentType = contentType;

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -1,7 +1,5 @@
 package qna.domain;
 
-import org.hibernate.annotations.CreationTimestamp;
-
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;

--- a/src/main/java/qna/domain/DeleteHistory.java
+++ b/src/main/java/qna/domain/DeleteHistory.java
@@ -1,6 +1,10 @@
 package qna.domain;
 
+import org.hibernate.annotations.CreationTimestamp;
+
 import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import java.time.LocalDateTime;
 import java.util.Objects;
@@ -8,11 +12,12 @@ import java.util.Objects;
 @Entity
 public class DeleteHistory {
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private ContentType contentType;
     private Long contentId;
     private Long deletedById;
-    private LocalDateTime createDate = LocalDateTime.now();
+    private LocalDateTime createDate;
 
     protected DeleteHistory() {
     }

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -1,28 +1,23 @@
 package qna.domain;
 
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
-
 import javax.persistence.*;
-import java.time.LocalDateTime;
 
 @Entity
-public class Question {
+public class Question extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     @Column(length = 100, nullable = false)
     private String title;
+
     @Lob
     private String contents;
+
     private Long writerId;
+
     @Column(nullable = false)
     private boolean deleted = false;
-    @CreationTimestamp
-    @Column(nullable = false)
-    private LocalDateTime createdAt;
-    @UpdateTimestamp
-    private LocalDateTime updatedAt;
 
     protected Question() {
     }

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -1,11 +1,19 @@
 package qna.domain;
 
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
 public class Question {
+    @Id
     private Long id;
     private String title;
     private String contents;
     private Long writerId;
     private boolean deleted = false;
+
+    protected Question() {
+    }
 
     public Question(String title, String contents) {
         this(null, title, contents);

--- a/src/main/java/qna/domain/Question.java
+++ b/src/main/java/qna/domain/Question.java
@@ -1,16 +1,28 @@
 package qna.domain;
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
 
 @Entity
 public class Question {
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    @Column(length = 100, nullable = false)
     private String title;
+    @Lob
     private String contents;
     private Long writerId;
+    @Column(nullable = false)
     private boolean deleted = false;
+    @CreationTimestamp
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
 
     protected Question() {
     }

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -1,11 +1,11 @@
 package qna.domain;
 
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 import qna.UnAuthorizedException;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Entity
@@ -13,11 +13,21 @@ public class User {
     public static final GuestUser GUEST_USER = new GuestUser();
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    @Column(length = 20, nullable = false, unique = true)
     private String userId;
+    @Column(length = 20, nullable = false)
     private String password;
+    @Column(length = 20, nullable = false)
     private String name;
+    @Column(length = 50)
     private String email;
+    @CreationTimestamp
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
 
     protected User() {
     }

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -1,33 +1,29 @@
 package qna.domain;
 
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
 import qna.UnAuthorizedException;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Entity
-public class User {
+public class User extends BaseEntity {
     public static final GuestUser GUEST_USER = new GuestUser();
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     @Column(length = 20, nullable = false, unique = true)
     private String userId;
+
     @Column(length = 20, nullable = false)
     private String password;
+
     @Column(length = 20, nullable = false)
     private String name;
+
     @Column(length = 50)
     private String email;
-    @CreationTimestamp
-    @Column(nullable = false)
-    private LocalDateTime createdAt;
-    @UpdateTimestamp
-    private LocalDateTime updatedAt;
 
     protected User() {
     }

--- a/src/main/java/qna/domain/User.java
+++ b/src/main/java/qna/domain/User.java
@@ -2,18 +2,24 @@ package qna.domain;
 
 import qna.UnAuthorizedException;
 
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 import java.util.Objects;
 
+@Entity
 public class User {
     public static final GuestUser GUEST_USER = new GuestUser();
 
+    @Id
     private Long id;
     private String userId;
     private String password;
     private String name;
     private String email;
 
-    private User() {
+    protected User() {
     }
 
     public User(String userId, String password, String name, String email) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,8 @@
 spring.datasource.url=jdbc:h2:~/test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 spring.datasource.username=sa
+
+spring.jpa.hibernate.ddl-auto=create
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.show-sql=true
+
+logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -1,6 +1,98 @@
 package qna.domain;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.TestConstructor;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@DataJpaTest
 public class AnswerTest {
     public static final Answer A1 = new Answer(UserTest.JAVAJIGI, QuestionTest.Q1, "Answers Contents1");
     public static final Answer A2 = new Answer(UserTest.SANJIGI, QuestionTest.Q1, "Answers Contents2");
+
+    AnswerRepository answers;
+
+    AnswerTest(AnswerRepository answers) {
+        this.answers = answers;
+    }
+
+    @Test
+    void findByIdAndDeletedFalse() {
+        Answer savedA1 = answers.save(A1);
+        Answer savedA2 = answers.save(A2);
+        savedA1.setDeleted(true);
+        answers.flush();
+
+        Optional<Answer> maybeA1 = answers.findByIdAndDeletedFalse(savedA1.getId());
+        Optional<Answer> maybeA2 = answers.findByIdAndDeletedFalse(savedA2.getId());
+
+        assertAll(
+                () -> assertThat(maybeA1).isEmpty(),
+                () -> assertThat(maybeA2).isPresent()
+        );
+    }
+
+    @Test
+    void findByQuestionIdAndDeletedFalse() {
+        Answer savedA1 = answers.save(A1);
+        Answer savedA2 = answers.save(A2);
+        savedA1.setDeleted(true);
+        answers.flush();
+
+        List<Answer> answersByQuestionIdAndDeletedFalse = answers.findByQuestionIdAndDeletedFalse(QuestionTest.Q1.getId());
+
+        assertThat(answersByQuestionIdAndDeletedFalse).hasSize(1);
+    }
+
+    @Test
+    void save() {
+        Answer saved = answers.save(A1);
+        assertAll(
+                () -> assertThat(saved.getId()).isNotNull(),
+                () -> assertThat(saved.getContents()).isEqualTo(A1.getContents())
+        );
+    }
+
+    @Test
+    void findById() {
+        Answer saved = answers.save(A1);
+        Answer expected = answers.findById(saved.getId()).get();
+
+        assertThat(expected).isEqualTo(saved);
+    }
+
+    @Test
+    void saveToUpdate() {
+        Answer saved = answers.save(A1);
+        answers.flush();
+
+        Answer answer = answers.findById(saved.getId()).get();
+        answer.setContents("수정된 내용");
+        Answer updated = answers.save(saved);
+        answers.flush(); // update 쿼리문 육안으로 확인
+
+        Answer exptected = answers.findById(updated.getId()).get();
+        assertThat(exptected.getContents()).isEqualTo(answer.getContents());
+    }
+
+    @Test
+    void delete() {
+        Answer saved = answers.save(A1);
+        answers.flush();
+
+        answers.delete(saved);
+        answers.flush(); // delete 쿼리문 육안으로 확인
+
+        Optional<Answer> maybe = answers.findById(saved.getId());
+        assertThat(maybe).isEmpty();
+    }
 }

--- a/src/test/java/qna/domain/AnswerTest.java
+++ b/src/test/java/qna/domain/AnswerTest.java
@@ -1,9 +1,6 @@
 package qna.domain;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.TestConstructor;
 

--- a/src/test/java/qna/domain/QuestionTest.java
+++ b/src/test/java/qna/domain/QuestionTest.java
@@ -1,6 +1,95 @@
 package qna.domain;
 
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.TestConstructor;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@DataJpaTest
 public class QuestionTest {
     public static final Question Q1 = new Question("title1", "contents1").writeBy(UserTest.JAVAJIGI);
     public static final Question Q2 = new Question("title2", "contents2").writeBy(UserTest.SANJIGI);
+
+    QuestionRepository questions;
+
+    QuestionTest(QuestionRepository questions) {
+        this.questions = questions;
+    }
+
+    @Test
+    void findByIdAndDeletedFalse() {
+        Question savedQ1 = questions.save(Q1);
+        Question savedQ2 = questions.save(Q2);
+        savedQ1.setDeleted(true);
+        questions.flush();
+
+        Optional<Question> maybeQ1 = questions.findByIdAndDeletedFalse(savedQ1.getId());
+        Optional<Question> maybeQ2 = questions.findByIdAndDeletedFalse(savedQ2.getId());
+
+        assertAll(
+                () -> assertThat(maybeQ1).isEmpty(),
+                () -> assertThat(maybeQ2).isPresent()
+        );
+    }
+
+    @Test
+    void findByDeletedFalse() {
+        Question savedQ1 = questions.save(Q1);
+        Question savedQ2 = questions.save(Q2);
+        savedQ1.setDeleted(true);
+        questions.flush();
+
+        List<Question> questionsByDeletedFalse = questions.findByDeletedFalse();
+
+        assertThat(questionsByDeletedFalse).hasSize(1);
+    }
+
+    @Test
+    void save() {
+        Question saved = questions.save(Q1);
+        assertAll(
+                () -> assertThat(saved.getId()).isNotNull(),
+                () -> assertThat(saved.getContents()).isEqualTo(Q1.getContents())
+        );
+    }
+
+    @Test
+    void findById() {
+        Question saved = questions.save(Q1);
+        Question expected = questions.findById(saved.getId()).get();
+
+        assertThat(expected).isEqualTo(saved);
+    }
+
+    @Test
+    void saveToUpdate() {
+        Question saved = questions.save(Q1);
+        questions.flush();
+
+        Question question = questions.findById(saved.getId()).get();
+        question.setContents("수정된 내용");
+        Question updated = questions.save(saved);
+        questions.flush(); // update 쿼리문 육안으로 확인
+
+        Question exptected = questions.findById(updated.getId()).get();
+        assertThat(exptected.getContents()).isEqualTo(question.getContents());
+    }
+
+    @Test
+    void delete() {
+        Question saved = questions.save(Q1);
+        questions.flush();
+
+        questions.delete(saved);
+        questions.flush(); // delete 쿼리문 육안으로 확인
+
+        Optional<Question> maybe = questions.findById(saved.getId());
+        assertThat(maybe).isEmpty();
+    }
 }

--- a/src/test/java/qna/domain/UserTest.java
+++ b/src/test/java/qna/domain/UserTest.java
@@ -1,6 +1,79 @@
 package qna.domain;
 
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.TestConstructor;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@DataJpaTest
 public class UserTest {
     public static final User JAVAJIGI = new User(1L, "javajigi", "password", "name", "javajigi@slipp.net");
     public static final User SANJIGI = new User(2L, "sanjigi", "password", "name", "sanjigi@slipp.net");
+
+    UserRepository users;
+
+    UserTest(UserRepository users) {
+        this.users = users;
+    }
+
+    @Test
+    void findByUserId() {
+        User saved = users.save(JAVAJIGI);
+        users.flush();
+
+        Optional<User> maybe = users.findByUserId(JAVAJIGI.getUserId());
+
+        assertThat(maybe).get().isEqualTo(saved);
+    }
+
+    @Test
+    void save() {
+        User saved = users.save(JAVAJIGI);
+
+        assertAll(
+                () -> assertThat(saved.getId()).isNotNull(),
+                () -> assertThat(saved.getUserId()).isEqualTo(JAVAJIGI.getUserId())
+        );
+    }
+
+    @Test
+    void findById() {
+        User saved = users.save(JAVAJIGI);
+
+        User expected = users.findById(saved.getId()).get();
+
+        assertThat(expected).isEqualTo(saved);
+    }
+
+    @Test
+    void saveToUpdate() {
+        User saved = users.save(JAVAJIGI);
+        users.flush();
+
+        User user = users.findById(saved.getId()).get();
+        user.setUserId("수정된 내용");
+        User updated = users.save(saved);
+        users.flush();
+
+        User exptected = users.findById(updated.getId()).get();
+        assertThat(exptected.getUserId()).isEqualTo(user.getUserId());
+    }
+
+    @Test
+    void delete() {
+        User saved = users.save(JAVAJIGI);
+        users.flush();
+
+        users.delete(saved);
+        users.flush();
+
+        Optional<User> maybe = users.findById(saved.getId());
+        assertThat(maybe).isEmpty();
+    }
 }

--- a/src/test/java/qna/domain/UserTest.java
+++ b/src/test/java/qna/domain/UserTest.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.TestConstructor;
 
-import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
안녕하세요!!
나아가팀 백엔드 이레, 채채, 코코닥, 루카입니다!

## 1. @CreationTimestamp, @CreatedDate 뭐가 나을까요?
- 차이가 Spring Data 에서 제공하는 기능과 jpa에서 자체적으로 제공하는 기능의 차이인 것 같습니다.
- @CreationTimestamp가 DB의 타임존에 의존적이여서 그렇지 않은 @CreatedDate를 사용하였습니다.

## 2. 컬럼명을 명시적으로 주는 것이 좋을까요?
- 컬럼명을 명시적으로 등록하지 않으면, 객체의 필드명 변화가 테이블의 필드명 변화로 이어지는 것 같아서 의존도가 커 보입니다.

감사합니다.